### PR TITLE
Adicionando o hook useDebouncedPromise

### DIFF
--- a/src/components/Promotion/Search/Search.jsx
+++ b/src/components/Promotion/Search/Search.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 // componentes
@@ -10,6 +10,7 @@ import useApi from "components/utils/useApi";
 import "./Search.css";
 
 const PromotionSearch = () => {
+  const mountRef = useRef(null);
   const [search, setSearch] = useState("");
   const [load, loadInfo] = useApi({
     url: "/promotions",
@@ -20,10 +21,15 @@ const PromotionSearch = () => {
       _sort: "id",
       title_like: search || undefined,
     },
+    debouncedDelay: 300,
   });
 
   useEffect(() => {
-    load();
+    load({
+      debounced: mountRef.current,
+    });
+
+    if (!mountRef.current) mountRef.current = true;
     // eslint-disable-next-line
   }, [search]);
 

--- a/src/components/utils/useApi.jsx
+++ b/src/components/utils/useApi.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 
 import axios from "axios";
 
+import useDebouncedPromise from "./useDebouncedPromise";
+
 /**
  * valores iniciais do request
  *
@@ -27,6 +29,7 @@ const initialRequestInfo = {
  */
 export default function useApi(config) {
   const [requestInfo, setRequestInfo] = useState(initialRequestInfo);
+  const debouncedAxios = useDebouncedPromise(axios, config.debouncedDelay);
 
   async function call(localConfig) {
     setRequestInfo({
@@ -35,9 +38,10 @@ export default function useApi(config) {
     });
 
     let response = null;
+    const makeRequest = localConfig.debounced ? debouncedAxios : axios;
 
     try {
-      response = await axios({
+      response = await makeRequest({
         baseURL: "http://localhost:5000",
         ...config,
         ...localConfig,
@@ -56,6 +60,8 @@ export default function useApi(config) {
     if (config.onCompleted) {
       config.onCompleted(response);
     }
+
+    return response;
   }
 
   return [call, requestInfo];

--- a/src/components/utils/useDebouncedPromise.jsx
+++ b/src/components/utils/useDebouncedPromise.jsx
@@ -1,0 +1,35 @@
+import { useRef } from "react";
+/**
+ * Recebe uma função e um tempo de delay para executar
+ * a mesma  de forma com que haja um atraso na execução da função
+ * @param {object} fn - função
+ * @param {int} delay - tempo
+ * @returns handler
+ */
+export default function useDebouncedPromise(fn, delay = 500) {
+  let timeoutRef = useRef(null);
+
+  /**
+   * Retorna uma função e transforma a mesma em uma promise
+   * passando para ela todos os parâmetros que foram passados para a
+   * função
+   * @param  {...any} params - parametros da função a ser convertida para promise
+   */
+  function handler(...params) {
+    return new Promise((resolve, reject) => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+
+      timeoutRef.current = window.setTimeout(async () => {
+        try {
+          let response = await fn(...params);
+
+          resolve(response);
+        } catch (error) {
+          reject(error);
+        }
+      }, delay);
+    });
+  }
+
+  return handler;
+}


### PR DESCRIPTION
Até então faziamos uma busca por um produto de promoção na barra de busca que é um controled component, assim sendo tem o seu valor controlado por um estado, alterações nesse estado fazem com que sejam executadas novas requisições a API, de forma com que tenhamos várias requisições sendo executadas ao mesmo tempo para a api, isso é ruim pois causa sobrecarga da api e também consome mais memória que deveria.

O hook adicionado `useDeboucendPromise` faz com que uma função seja executada apenas depois de um intervalo de tempo, cujo a referência é salva dentro de um `useRef` assim feito para que a referência não seja perdida dentro do ciclo de vida da função. O `useDebouncedPromise` recebe dois parâmetros, o primeiro deles é um função que vai ser colocada dentro de uma promise e que deve ser executada após o intervalo de tempo determinado no segundo parametro, que é o delay, porém esse segundo parâmetro seja opicional de ser passado, já que tem como valor padrão 500ms.

Adicionamos também a propriedade _debounced_ no `useApi` porque nem sempre desejamos utilizar uma _**debounced instance**_ do axios, assim sendo a instância utilizada vai depender dessa variável estar definida.